### PR TITLE
Added a condition to check 'numax' parameter

### DIFF
--- a/src/pysyd/target.py
+++ b/src/pysyd/target.py
@@ -729,6 +729,10 @@ class Target:
             self.params['results'] = {}
         if 'plotting' not in self.params:
             self.params['plotting'] = {}
+			
+		if self.params['numax'] is not None:
+        	self.params['estimate'] = False
+			
         if self.params['estimate']:
             # get initial values and fix data
             self.initial_estimates()


### PR DESCRIPTION
---
name: Pull request
about: Contribute to this project!
title: ''
labels: ''
assignees: ''

---

------

## Relevant Materials

### Description
Currently, `Target.estimate_parameters` relies on the `self.params['estimate']` flag. When using `pySYD` as a library, users often provide a numax guess after` add_targets` but before `process_star`. In this case, the flag remains `True`, causing the automated routine to run and overwrite the user's manual guess.
This PR ensures that if a numax value is manually provided, the estimation module is correctly skipped, matching the existing docstring.

Using the checklist as a guide, please provide more details about the nature of the pull request. 

### Attachments & Supporting Files

Please provide any relevant files i.e. data if adding a new target to a test or as an example

### Other

Any other relevant context i.e. reference/link if directly addressing an existing issue

------

## Summary Checklist:

- Is this a major request? <ul><li>- [ ] Yes <br/> &rightarrow; Have you already submitted an issue outlining the request?<ul><li>- [ ] Yes</li><li>- [ ] No</li></ul></li><li>- [ ] No</li><li>- [ ] IDK</li></ul>
- What type of request is this? <ul><li>- [ ] New feature</li><li>- [ ] Modification</li><li>- [ ] Suggested update</li><li>- [ ] Other*</li></ul>
- Why is the change needed? <ul><li>- [ ] General improvement</li><li>- [ ] Solves a problem </li><li>- [ ] Relevant to an open issue <br/> &rightarrow; Did you provide the link?<ul><li>- [ ] Yes</li><li>- [ ] No</li></ul></li><li>- [ ] Increased efficiency and/or speed</li><li>- [ ] Other?*</li></ul>
- Did you test your changes? <ul><li>- [ ] Yes</li><li>- [ ] No (please do ***not*** submit a request until you have)</li><li>- [ ] N/A</li></ul>
- Does the code comply with our [style guide](https://github.com/ashleychontos/pySYD/blob/master/CONTRIBUTING.md) and is it complete with docstrings and other relevant documentation? <ul><li>- [ ] Yes</li><li>- [ ] No</li></ul>
- Will this request require any changes from our end? <ul><li>- [ ] Yes**</li><li>- [ ] No</li></ul>
<br/>
* If 'Other' was selected at any point, please expand on each of these points in more detail below. <br/>** If 'Yes' was selected for the last bullet, please elaborate below. 

------
